### PR TITLE
Add expression function for using MagDec within Layouts

### DIFF
--- a/MagneticDeclination/Magnetic_declination.py
+++ b/MagneticDeclination/Magnetic_declination.py
@@ -40,6 +40,7 @@ import os.path
 # IMPORT OTHER
 from datetime import *
 from . import geomag
+from .Magnetic_declination_functions import InitMagDecFunctions, UnloadMagDecFunctions
 from qgis.gui import *
 from qgis.core import *
 import math
@@ -209,6 +210,7 @@ class MagneticDeclination(QObject):
             text=self.tr(u'Magnetic Declination'),
             callback=self.run,
             parent=self.iface.mainWindow())
+        InitMagDecFunctions()
 
 
     def unload(self):
@@ -220,6 +222,7 @@ class MagneticDeclination(QObject):
             self.iface.removeToolBarIcon(action)
         # remove the toolbar
         del self.toolbar
+        UnloadMagDecFunctions()
 
 
     def run(self):

--- a/MagneticDeclination/Magnetic_declination_functions.py
+++ b/MagneticDeclination/Magnetic_declination_functions.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ MagneticDeclination
+                              -------------------
+        begin                : 2015-04-08
+        git sha              : $Format:%H$
+        copyright            : (C) 2023 by Matt Cengia
+        email                : mattcen@mattcen.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+from datetime import date
+from MagneticDeclination.geomag.geomag import GeoMag
+from qgis.core import (
+    QgsCoordinateReferenceSystem,
+    QgsCoordinateTransform,
+    QgsProject,
+    QgsExpression,
+)
+from qgis.utils import qgsfunction
+
+group_name = "Magnetic Declination"
+
+
+def InitMagDecFunctions():
+    QgsExpression.registerFunction(layout_map_mag_dec)
+
+
+def UnloadMagDecFunctions():
+    QgsExpression.unregisterFunction("layout_map_mag_dec")
+
+
+@qgsfunction(args="auto", group=group_name)
+def layout_map_mag_dec(layout_map, feature, parent):
+    """Calculate the magnetic declination of a given point
+    <h2>Arguments</h2>
+    <ul>
+      <li>layout_map -- A layout map to find the magnetic declination of</li>
+    </ul>
+    <h2>Example</h2>
+    Within a print layout text area:
+
+    <pre>
+    format_number(abs(layout_map_mag_dec(item_variables('Map 1'))), 2)
+    </pre>
+    """
+    my_point = layout_map['map_extent_center'].asPoint()
+    crs = QgsCoordinateReferenceSystem(layout_map['map_crs'])
+    altitude = 0
+    my_date = date.today()
+    project = QgsProject.instance()
+    wgs84 = QgsCoordinateReferenceSystem('EPSG:4326')
+    transformContext = project.transformContext()
+    xform = QgsCoordinateTransform(crs, wgs84, transformContext)
+
+    new_point = xform.transform(my_point)
+    return GeoMag().GeoMag(new_point.x(), new_point.y(), h=altitude, time=my_date).dec


### PR DESCRIPTION
It's useful to be able to display a map's magnetic declination alongside the map itself on the layout.

This code creates a function that can be used in the Expression editor to retrieve the center-point and crs of a given map within a Print Layout, and return a double representing the magnetic declination at that point.

This can then be used in a text area or similar on a print layout to display that declination.

For example:

![image](https://github.com/Hacked-Crew/Magnetic-Declination/assets/4273659/d337d7d5-51c9-4c82-85a2-8d4d13a8179b)

The item text for the right-hand text area above is defined as:
```
Magnetic
North
Declination:
[% format_number(abs(layout_map_mag_dec(item_variables('Map 1'))), 2) %]º
```