### PR TITLE
Update Magnetic_declination.py to swap TVMDCAW and CDMVTAE calculations

### DIFF
--- a/MagneticDeclination/Magnetic_declination.py
+++ b/MagneticDeclination/Magnetic_declination.py
@@ -405,9 +405,9 @@ class MagneticDeclination(QObject):
         self.vAr = (str(degrees) + u'\u00B0' + str(minutes) + u'\u2032')
         #
         if simple_XtoMagnetic == 1:
-            Rheading = (float(self.Rdeclination) + float(simple_heading)) % 360 
-        else:
             Rheading = geomag.mag_heading(float(simple_heading), float(self.simple_latitude), float(self.simple_longitude), float(simple_Cheight), date(simple_year,simple_month,simple_day))
+        else:
+            Rheading = (float(self.Rdeclination) + float(simple_heading)) % 360 
         #
         self.dlg.declination_lineEdit.setText(str(self.Rdeclination) + u'\u00B0')
         self.dlg.heading_lineEdit.setText(str(Rheading) + u'\u00B0')


### PR DESCRIPTION
Fix the https://github.com/Hacked-Crew/Magnetic-Declination/issues/2#issuecomment-1876016654 issue by swapping the calculations so the TVMDCAW and CDMVTAE calculation calls here:

https://github.com/Hacked-Crew/Magnetic-Declination/blob/9ea3356558224a4fd86777c25b8d461eee4b11aa/MagneticDeclination/Magnetic_declination.py#L407-L410

so that if `simple_XtoMagnetic == 1:`  calls  `geomag.mag_heading()` function, etc....

This is a better solution than  https://github.com/Hacked-Crew/Magnetic-Declination/pull/9