### PR TITLE
Fix layout_map_mag_dec function

### DIFF
--- a/MagneticDeclination/Magnetic_declination_functions.py
+++ b/MagneticDeclination/Magnetic_declination_functions.py
@@ -63,4 +63,4 @@ def layout_map_mag_dec(layout_map, feature, parent):
     xform = QgsCoordinateTransform(crs, wgs84, transformContext)
 
     new_point = xform.transform(my_point)
-    return GeoMag().GeoMag(new_point.x(), new_point.y(), h=altitude, time=my_date).dec
+    return GeoMag().GeoMag(new_point.y(), new_point.x(), h=altitude, time=my_date).dec


### PR DESCRIPTION
`GeoMag()` call expects to get coordinates in the order of: latitude, longitude. This means that we should use first the `y()` method of `new_point`, and then `x()`.

Currently that it's opposite, which causes the declination calculated with the layout function to be different than what the main part of the plugin calculates and what the compass rose shows.

This commit fixes the call to `GeoMag()` method by passing the coordinate in the proper order.

This fixes bug described in https://github.com/Hacked-Crew/Magnetic-Declination/issues/8. 